### PR TITLE
vars.yml: add missing dirs for docker and data

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -53,6 +53,10 @@ local_network: "<your local network>"
 
 shell: /usr/bin/fish
 
+docker_dir: /home/{{ username }}/docker
+
+data_dir: /home/{{ username }}/data
+
 packages:
   - unzip
   - wget


### PR DESCRIPTION
Not defining default values for `docker_dir` and
`data_dir` results in playbook failure
This change sets default values for both variables

Issue: none