### PR TITLE
mysql.yml: join duplicate `env` entry for mysql service

### DIFF
--- a/roles/services/tasks/mysql.yml
+++ b/roles/services/tasks/mysql.yml
@@ -5,6 +5,10 @@
     env:
       PUID: "{{ puid }}"
       PGID: "{{ pgid }}"
+      MYSQL_ROOT_PASSWORD: "{{ mysql_password }}"
+      MYSQL_DATABASE: "admin"
+      MYSQL_USER: "admin"
+      MYSQL_PASSWORD: "{{ mysql_password }}"
     state: started
     networks:
       - name: homelab
@@ -14,11 +18,6 @@
       - "{{ data_dir }}/mysql/dbbackups:/var/backups/mysql"
 
     restart_policy: unless-stopped
-    env:
-      MYSQL_ROOT_PASSWORD: "{{ mysql_password }}"
-      MYSQL_DATABASE: "admin"
-      MYSQL_USER: "admin"
-      MYSQL_PASSWORD: "{{ mysql_password }}"
     labels:
       traefik.enable: "true"
       traefik.docker.network: "homelab"


### PR DESCRIPTION
The `env` key is duplicated causing `PUID` and `GUID` to be ignored
All variables are now set in a single `env` entry

Issue: none