### PR TITLE
harden(docker): read-only docker-socket-proxy for Traefik, diun, homarr

### DIFF
--- a/roles/services/tasks/diun.yml
+++ b/roles/services/tasks/diun.yml
@@ -13,7 +13,6 @@
     state: started
     restart_policy: unless-stopped
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "{{ docker_dir }}/diun:/data"
     env:
       TZ: "{{ timezone }}"
@@ -22,6 +21,9 @@
       DIUN_WATCH_SCHEDULE: "0 6 * * *"
       DIUN_WATCH_FIRSTCHECKNOTIF: "false"
       DIUN_PROVIDERS_DOCKER: "true"
+      # SECURITY: reach Docker via the read-only socket proxy instead of mounting the raw
+      # socket (diun only needs to READ container/image info). GET-only, no escape surface.
+      DIUN_PROVIDERS_DOCKER_ENDPOINT: "tcp://docker-socket-proxy:2375"
       DIUN_PROVIDERS_DOCKER_WATCHBYDEFAULT: "true"
       # Push notifications via ntfy. The topic name is the only access control on
       # ntfy.sh (anyone who knows it can read/post), so it lives in vault.yml.

--- a/roles/services/tasks/docker_socket_proxy.yml
+++ b/roles/services/tasks/docker_socket_proxy.yml
@@ -1,0 +1,38 @@
+---
+# Read-only Docker-socket proxy (tecnativa/docker-socket-proxy).
+#
+# Lets containers that only need to READ the Docker API (Traefik = route discovery,
+# diun = image-update watch, homarr = container-status widget) reach it WITHOUT
+# bind-mounting the raw /var/run/docker.sock — which is host-root-equivalent (write/exec
+# access = container escape). This proxy is the ONLY non-management thing that mounts the
+# real socket (read-only); it exposes a scoped, GET-only TCP API (port 2375) on the
+# homelab network and DENIES all writes (POST=0 → no create/start/stop/exec). NOT
+# published to the host.
+#
+# Consumers (Traefik, diun, homarr) point at  tcp://docker-socket-proxy:2375 . Portainer
+# deliberately keeps the raw socket (it needs write access for management; gated behind
+# the SSO portal, not publicly exposed).
+- name: Create docker-socket-proxy container
+  community.docker.docker_container:
+    name: docker-socket-proxy
+    image: tecnativa/docker-socket-proxy:0.3.0
+    state: started
+    restart_policy: unless-stopped
+    networks:
+      - name: homelab
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    security_opts:
+      - "no-new-privileges:true"
+    env:
+      # GET-only allowlist — exactly what Traefik (containers/networks/events), diun
+      # (containers/images) and homarr (containers) need to read; everything else (and
+      # ALL writes) stays denied by default.
+      CONTAINERS: "1"
+      IMAGES: "1"
+      NETWORKS: "1"
+      INFO: "1"
+      VERSION: "1"
+      PING: "1"
+      POST: "0"
+      LOG_LEVEL: "warning"

--- a/roles/services/tasks/homarr.yml
+++ b/roles/services/tasks/homarr.yml
@@ -14,9 +14,13 @@
     env:
       SECRET_ENCRYPTION_KEY: "{{ homarr_encryption_key }}"
       TZ: "{{ timezone }}"
+      # SECURITY: reach Docker via the read-only socket proxy, NOT the raw root socket.
+      # homarr is public-facing; a raw /var/run/docker.sock = host root if it is ever
+      # compromised. The proxy is GET-only (no create/start/exec). Also point homarr's
+      # in-app Docker integration at tcp://docker-socket-proxy:2375 to repopulate widgets.
+      DOCKER_HOST: "tcp://docker-socket-proxy:2375"
     volumes:
       - "{{ docker_dir }}/homarr:/appdata"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
     labels:
       traefik.enable: "true"
       traefik.http.routers.homarr.entrypoints: "http"

--- a/roles/services/tasks/main.yml
+++ b/roles/services/tasks/main.yml
@@ -2,6 +2,7 @@
   ansible.builtin.include_tasks: "roles/services/tasks/{{ item }}.yml"
   loop:
     - authelia
+    - docker_socket_proxy   # read-only socket proxy; MUST be created before its consumers (traefik, homarr, diun)
     - traefik
     - code_server
     - dashdot

--- a/roles/services/tasks/traefik.yml
+++ b/roles/services/tasks/traefik.yml
@@ -34,7 +34,9 @@
           address: ":443"
       providers:
         docker:
-          endpoint: "unix:///var/run/docker.sock"
+          # Read the Docker API via the read-only socket-proxy (GET-only), NOT the raw
+          # /var/run/docker.sock — removes the host-root escape surface from the proxy.
+          endpoint: "tcp://docker-socket-proxy:2375"
           exposedByDefault: false
         file:
           directory: /dynamic
@@ -114,8 +116,10 @@
       - "80:80"
       - "443:443"
 
+    # SECURITY: no raw /var/run/docker.sock mount — Traefik reaches the Docker API through
+    # the read-only docker-socket-proxy (endpoint set in traefik.yml above), so a Traefik
+    # compromise can no longer reach a writable socket = no host-root escape from the proxy.
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - "{{ docker_dir }}/traefik/data/acme.json:/acme.json"
       - "{{ docker_dir }}/traefik/data/traefik.yml:/traefik.yml:ro"
       - "{{ docker_dir }}/traefik/data/dynamic:/dynamic:ro"


### PR DESCRIPTION
## What

Run the containers that only need to **read** the Docker API — Traefik (route discovery), diun (image-update watch), and homarr (container-status widget) — through a read-only [`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy) instead of bind-mounting the raw `/var/run/docker.sock`.

## Why

Mounting `/var/run/docker.sock` into a container is effectively giving it **root on the host** — the Docker API lets a client create privileged containers, bind-mount the host filesystem, exec into containers, etc. A `:ro` mount does **not** help (it only makes the socket file read-only; the API is still fully usable). So an RCE in any socket-mounting container can escape to the host. homarr and Traefik are network-facing, which makes this especially worth closing.

## How

- New `docker_socket_proxy` role: `tecnativa/docker-socket-proxy` with a **GET-only** allowlist (`POST=0` → no create/start/stop/exec), `no-new-privileges`, the real socket mounted **read-only**, on the internal network only and **not** published to the host.
- Traefik: docker provider `endpoint` → `tcp://docker-socket-proxy:2375` and the raw socket mount removed.
- diun: `DIUN_PROVIDERS_DOCKER_ENDPOINT` → the proxy; raw socket mount removed.
- homarr: `DOCKER_HOST` → the proxy; raw socket mount removed.
- `main.yml`: the proxy is created **before** its consumers.

Portainer intentionally keeps the raw socket — it needs write access for container management and is gated behind the SSO portal (not publicly exposed).

## Notes

- Verified on a live deployment: the proxy answers Traefik's needs (`/containers`, `/networks`, `/events`, `/version`), writes return `403`, and all routes + TLS stay healthy.
- `community.docker.docker_container` does not detect a *removed* bind mount in `volumes`, so applying the Traefik change to an existing container needs a one-shot `recreate: true` (or `docker rm` + redeploy).